### PR TITLE
Moved function from configure-rdo.sh to utils.sh

### DIFF
--- a/configure-rdo.sh
+++ b/configure-rdo.sh
@@ -62,20 +62,6 @@ if [ -n "$HYPERV_COMPUTE_VM_IP" ]; then
     exec_with_retry "$BASEDIR/rename-windows-host.sh $HYPERV_COMPUTE_VM_IP $HYPERV_ADMIN $HYPERV_PASSWORD $HYPERV_COMPUTE_VM_NAME" 30 30
 fi
 
-config_openstack_network_adapter () {
-    SSHUSER_HOST=$1
-    ADAPTER=$2
-
-    run_ssh_cmd_with_retry $SSHUSER_HOST "cat << EOF > /etc/sysconfig/network-scripts/ifcfg-$ADAPTER
-DEVICE="$ADAPTER"
-BOOTPROTO="none"
-MTU="1500"
-ONBOOT="yes"
-EOF"
-
-    run_ssh_cmd_with_retry $SSHUSER_HOST "ifup $ADAPTER"
-}
-
 echo "Configuring networking"
 
 set_hostname $RDO_ADMIN@$CONTROLLER_VM_IP $CONTROLLER_VM_NAME.$DOMAIN $CONTROLLER_VM_IP

--- a/utils.sh
+++ b/utils.sh
@@ -20,6 +20,20 @@ exec_with_retry2 () {
     return $EXIT
 }
 
+config_openstack_network_adapter () {
+    SSHUSER_HOST=$1
+    ADAPTER=$2
+
+    run_ssh_cmd_with_retry $SSHUSER_HOST "cat << EOF > /etc/sysconfig/network-scripts/ifcfg-$ADAPTER
+    DEVICE="$ADAPTER"
+    BOOTPROTO="none"
+    MTU="1500"
+    ONBOOT="yes"
+    EOF"
+
+    run_ssh_cmd_with_retry $SSHUSER_HOST "ifup $ADAPTER"
+}
+
 exec_with_retry () {
     CMD=$1
     MAX_RETRIES=${2-10}


### PR DESCRIPTION
When trying to run configure-rdo.sh, I received an error
"config_openstack_network_adapter not found". So I moved the function
from configure-rdo.sh to utils.sh and the problem is now solved. It solves
this error on Havana and Icehouse.
