### PR TITLE
Added packstack support for Icehouse

### DIFF
--- a/deploy-rdo.sh
+++ b/deploy-rdo.sh
@@ -22,7 +22,7 @@ BASEDIR=$(dirname $0)
 . $BASEDIR/utils.sh
 
 case "$OPENSTACK_RELEASE" in
-grizzly|havana)
+grizzly|havana|icehouse)
     ;;
 *)
     echoerr "Unsupported OpenStack release: $OPENSTACK_RELEASE"


### PR DESCRIPTION
In icehouse packstack answer file, L3, DHCP and METADATA hosts
are all set in CONFIG_NETWORK_HOSTS. CONFIG_NOVA_COMPUTE_HOSTS
was renamed to CONFIG_COMPUTE_HOSTS.
