### PR TITLE
adding a registry key to the WinRM access script for use by automation

### DIFF
--- a/SetupWinRMAccessSelfSigned.ps1
+++ b/SetupWinRMAccessSelfSigned.ps1
@@ -99,3 +99,7 @@ New-Item -Path wsman:\localhost\listener -transport https -address * -Certificat
 Set-Item wsman:\localhost\service\Auth\Basic -Value $true
 
 CreateWinRMHttpsFirewallRule
+
+#reg key for use by automation to verify this script has completed
+if (-not (Test-Path HKLM:\SOFTWARE\cloudbase)) {New-Item -Path HKLM:\SOFTWARE\cloudbase}
+Set-ItemProperty -Path HKLM:\SOFTWARE\cloudbase -Name WinRMAccess -Value 1


### PR DESCRIPTION
Using a registry key instead of a file to be less obnoxious to those that don't need it.
